### PR TITLE
Fnd 1860 find related cache keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+target/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.goeuro</groupId>
+    <artifactId>couchbase-actions</artifactId>
+    <version>latest-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>couchbase-actions</name>
+
+    <properties>
+        <java.version>14</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <lombok.version>1.18.12</lombok.version>
+    </properties>
+
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <!--TEST-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.5.2</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.17.2</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <repositories>
+        <!-- to find provider lib -->
+        <repository>
+            <id>GoEuro Nexus</id>
+            <name>GoEuro Central</name>
+            <url>http://nexus.goeuro.int/content/groups/goeuro/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <compilerArgument>-Xlint:unchecked,deprecation</compilerArgument>
+                </configuration>
+            </plugin>
+            <!-- see: https://github.com/codecov/example-java -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/code/base/omio/CacheKey.java
+++ b/src/main/java/code/base/omio/CacheKey.java
@@ -1,0 +1,34 @@
+package code.base.omio;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class CacheKey {
+
+    private String provider;
+
+    private Long departurePositionId;
+
+    private Long arrivalPositionId;
+
+    private LocalDate departureDate;
+
+    private LocalDate returnDate;
+
+    private int seniorCount;
+
+    private int adultCount;
+
+    private int youthCount;
+
+    private int childCount;
+
+    private int infantCount;
+
+    private String discountCardHash;
+
+    private String abParameterHash;
+
+}

--- a/src/main/java/code/base/omio/CacheKeyUtils.java
+++ b/src/main/java/code/base/omio/CacheKeyUtils.java
@@ -1,0 +1,94 @@
+package code.base.omio;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+
+public class CacheKeyUtils {
+
+    public List<String> getRelatedCacheKeys(String cacheKeyToDelete) {
+        List<String> relatedCacheKeys = new ArrayList<>();
+        CacheKey cacheKey = toCacheKeyObject(cacheKeyToDelete);
+        //senior
+        int seniorCount = cacheKey.getSeniorCount();
+        int index = seniorCount;
+        while (calculatePassengerCountLessThan9(cacheKey)) {
+            index++;
+            cacheKey.setSeniorCount(index);
+            relatedCacheKeys.add(toCacheKeyString(cacheKey));
+        }
+        cacheKey.setSeniorCount(seniorCount);
+
+        //adult
+        int adultCount = cacheKey.getAdultCount();
+        index = adultCount;
+        while (calculatePassengerCountLessThan9(cacheKey)) {
+            index++;
+            cacheKey.setAdultCount(index);
+            relatedCacheKeys.add(toCacheKeyString(cacheKey));
+        }
+        cacheKey.setAdultCount(adultCount);
+
+        //youth
+        int youthCount = cacheKey.getYouthCount();
+        index = youthCount;
+        while (calculatePassengerCountLessThan9(cacheKey)) {
+            index++;
+            cacheKey.setYouthCount(index);
+            relatedCacheKeys.add(toCacheKeyString(cacheKey));
+        }
+        cacheKey.setYouthCount(youthCount);
+
+        //child
+        int childCount = cacheKey.getChildCount();
+        index = childCount;
+        while (calculatePassengerCountLessThan9(cacheKey)) {
+            index++;
+            cacheKey.setChildCount(index);
+            relatedCacheKeys.add(toCacheKeyString(cacheKey));
+        }
+        cacheKey.setChildCount(childCount);
+
+        return relatedCacheKeys;
+    }
+
+    private CacheKey toCacheKeyObject(String cacheKey) {
+        String[] cacheKeySplits = cacheKey.split("\\|");
+        CacheKey cacheKeyParts = new CacheKey();
+        cacheKeyParts.setProvider(cacheKeySplits[0]);
+        cacheKeyParts.setDeparturePositionId(Long.parseLong(cacheKeySplits[1]));
+        cacheKeyParts.setArrivalPositionId(Long.parseLong(cacheKeySplits[2]));
+        cacheKeyParts.setDepartureDate(LocalDate.parse(cacheKeySplits[3]));
+        cacheKeyParts.setReturnDate(cacheKeySplits[4] == null ? null: LocalDate.parse(cacheKeySplits[4]));
+        cacheKeyParts.setSeniorCount(Integer.parseInt(cacheKeySplits[5]));
+        cacheKeyParts.setAdultCount(Integer.parseInt(cacheKeySplits[6]));
+        cacheKeyParts.setYouthCount(Integer.parseInt(cacheKeySplits[7]));
+        cacheKeyParts.setChildCount(Integer.parseInt(cacheKeySplits[8]));
+        cacheKeyParts.setInfantCount(Integer.parseInt(cacheKeySplits[9]));
+        cacheKeyParts.setDiscountCardHash(cacheKeySplits[10]);
+        cacheKeyParts.setAbParameterHash(cacheKeySplits[11]);
+        return cacheKeyParts;
+    }
+
+    private String toCacheKeyString(CacheKey cacheKey) {
+        StringJoiner stringJoiner = new StringJoiner("|");
+        stringJoiner.add(cacheKey.getProvider());
+        stringJoiner.add(String.valueOf(cacheKey.getDeparturePositionId()));
+        stringJoiner.add(String.valueOf(cacheKey.getArrivalPositionId()));
+        stringJoiner.add(cacheKey.getDepartureDate().toString());
+        stringJoiner.add(cacheKey.getReturnDate() == null ? null : cacheKey.getReturnDate().toString());
+        stringJoiner.add(String.valueOf(cacheKey.getSeniorCount()));
+        stringJoiner.add(String.valueOf(cacheKey.getAdultCount()));
+        stringJoiner.add(String.valueOf(cacheKey.getYouthCount()));
+        stringJoiner.add(String.valueOf(cacheKey.getChildCount()));
+        stringJoiner.add(String.valueOf(cacheKey.getInfantCount()));
+        stringJoiner.add(cacheKey.getDiscountCardHash());
+        stringJoiner.add(cacheKey.getAbParameterHash());
+        return stringJoiner.toString();
+    }
+
+    private boolean calculatePassengerCountLessThan9(CacheKey cacheKey) {
+        return cacheKey.getSeniorCount()+ cacheKey.getAdultCount()+ cacheKey.getYouthCount()+ cacheKey.getChildCount()+ cacheKey.getInfantCount() < 9;
+    }
+}

--- a/src/main/java/code/base/omio/CacheKeyUtils.java
+++ b/src/main/java/code/base/omio/CacheKeyUtils.java
@@ -10,7 +10,47 @@ public class CacheKeyUtils {
     public List<String> getRelatedCacheKeys(String cacheKeyToDelete) {
         List<String> relatedCacheKeys = new ArrayList<>();
         CacheKey cacheKey = toCacheKeyObject(cacheKeyToDelete);
-        //senior
+        populateSeniorRelatedCacheKeys(relatedCacheKeys, cacheKey);
+        populateAdultRelatedCacheKeys(relatedCacheKeys, cacheKey);
+        populateYouthRelatedCacheKeys(relatedCacheKeys, cacheKey);
+        populateChildrenRelatedCacheKeys(relatedCacheKeys, cacheKey);
+        return relatedCacheKeys;
+    }
+
+    private void populateChildrenRelatedCacheKeys(List<String> relatedCacheKeys, CacheKey cacheKey) {
+        int childCount = cacheKey.getChildCount();
+        int index = childCount;
+        while (ifTotalPassengerCountLessThan9(cacheKey)) {
+            index++;
+            cacheKey.setChildCount(index);
+            relatedCacheKeys.add(toCacheKeyString(cacheKey));
+        }
+        cacheKey.setChildCount(childCount);
+    }
+
+    private void populateYouthRelatedCacheKeys(List<String> relatedCacheKeys, CacheKey cacheKey) {
+        int youthCount = cacheKey.getYouthCount();
+        int index = youthCount;
+        while (ifTotalPassengerCountLessThan9(cacheKey)) {
+            index++;
+            cacheKey.setYouthCount(index);
+            relatedCacheKeys.add(toCacheKeyString(cacheKey));
+        }
+        cacheKey.setYouthCount(youthCount);
+    }
+
+    private void populateAdultRelatedCacheKeys(List<String> relatedCacheKeys, CacheKey cacheKey) {
+        int adultCount = cacheKey.getAdultCount();
+        int index = adultCount;
+        while (ifTotalPassengerCountLessThan9(cacheKey)) {
+            index++;
+            cacheKey.setAdultCount(index);
+            relatedCacheKeys.add(toCacheKeyString(cacheKey));
+        }
+        cacheKey.setAdultCount(adultCount);
+    }
+
+    private void populateSeniorRelatedCacheKeys(List<String> relatedCacheKeys, CacheKey cacheKey) {
         int seniorCount = cacheKey.getSeniorCount();
         int index = seniorCount;
         while (ifTotalPassengerCountLessThan9(cacheKey)) {
@@ -19,38 +59,6 @@ public class CacheKeyUtils {
             relatedCacheKeys.add(toCacheKeyString(cacheKey));
         }
         cacheKey.setSeniorCount(seniorCount);
-
-        //adult
-        int adultCount = cacheKey.getAdultCount();
-        index = adultCount;
-        while (ifTotalPassengerCountLessThan9(cacheKey)) {
-            index++;
-            cacheKey.setAdultCount(index);
-            relatedCacheKeys.add(toCacheKeyString(cacheKey));
-        }
-        cacheKey.setAdultCount(adultCount);
-
-        //youth
-        int youthCount = cacheKey.getYouthCount();
-        index = youthCount;
-        while (ifTotalPassengerCountLessThan9(cacheKey)) {
-            index++;
-            cacheKey.setYouthCount(index);
-            relatedCacheKeys.add(toCacheKeyString(cacheKey));
-        }
-        cacheKey.setYouthCount(youthCount);
-
-        //child
-        int childCount = cacheKey.getChildCount();
-        index = childCount;
-        while (ifTotalPassengerCountLessThan9(cacheKey)) {
-            index++;
-            cacheKey.setChildCount(index);
-            relatedCacheKeys.add(toCacheKeyString(cacheKey));
-        }
-        cacheKey.setChildCount(childCount);
-
-        return relatedCacheKeys;
     }
 
     private CacheKey toCacheKeyObject(String cacheKey) {
@@ -60,7 +68,7 @@ public class CacheKeyUtils {
         cacheKeyParts.setDeparturePositionId(Long.parseLong(cacheKeySplits[1]));
         cacheKeyParts.setArrivalPositionId(Long.parseLong(cacheKeySplits[2]));
         cacheKeyParts.setDepartureDate(LocalDate.parse(cacheKeySplits[3]));
-        cacheKeyParts.setReturnDate(cacheKeySplits[4] == null ? null: LocalDate.parse(cacheKeySplits[4]));
+        cacheKeyParts.setReturnDate((cacheKeySplits[4] == null || "".equals(cacheKeySplits[4].trim()))? null: LocalDate.parse(cacheKeySplits[4]));
         cacheKeyParts.setSeniorCount(Integer.parseInt(cacheKeySplits[5]));
         cacheKeyParts.setAdultCount(Integer.parseInt(cacheKeySplits[6]));
         cacheKeyParts.setYouthCount(Integer.parseInt(cacheKeySplits[7]));
@@ -77,7 +85,7 @@ public class CacheKeyUtils {
         stringJoiner.add(String.valueOf(cacheKey.getDeparturePositionId()));
         stringJoiner.add(String.valueOf(cacheKey.getArrivalPositionId()));
         stringJoiner.add(cacheKey.getDepartureDate().toString());
-        stringJoiner.add(cacheKey.getReturnDate() == null ? null : cacheKey.getReturnDate().toString());
+        stringJoiner.add(cacheKey.getReturnDate() == null ? "" : cacheKey.getReturnDate().toString());
         stringJoiner.add(String.valueOf(cacheKey.getSeniorCount()));
         stringJoiner.add(String.valueOf(cacheKey.getAdultCount()));
         stringJoiner.add(String.valueOf(cacheKey.getYouthCount()));

--- a/src/main/java/code/base/omio/CacheKeyUtils.java
+++ b/src/main/java/code/base/omio/CacheKeyUtils.java
@@ -13,7 +13,7 @@ public class CacheKeyUtils {
         //senior
         int seniorCount = cacheKey.getSeniorCount();
         int index = seniorCount;
-        while (calculatePassengerCountLessThan9(cacheKey)) {
+        while (ifTotalPassengerCountLessThan9(cacheKey)) {
             index++;
             cacheKey.setSeniorCount(index);
             relatedCacheKeys.add(toCacheKeyString(cacheKey));
@@ -23,7 +23,7 @@ public class CacheKeyUtils {
         //adult
         int adultCount = cacheKey.getAdultCount();
         index = adultCount;
-        while (calculatePassengerCountLessThan9(cacheKey)) {
+        while (ifTotalPassengerCountLessThan9(cacheKey)) {
             index++;
             cacheKey.setAdultCount(index);
             relatedCacheKeys.add(toCacheKeyString(cacheKey));
@@ -33,7 +33,7 @@ public class CacheKeyUtils {
         //youth
         int youthCount = cacheKey.getYouthCount();
         index = youthCount;
-        while (calculatePassengerCountLessThan9(cacheKey)) {
+        while (ifTotalPassengerCountLessThan9(cacheKey)) {
             index++;
             cacheKey.setYouthCount(index);
             relatedCacheKeys.add(toCacheKeyString(cacheKey));
@@ -43,7 +43,7 @@ public class CacheKeyUtils {
         //child
         int childCount = cacheKey.getChildCount();
         index = childCount;
-        while (calculatePassengerCountLessThan9(cacheKey)) {
+        while (ifTotalPassengerCountLessThan9(cacheKey)) {
             index++;
             cacheKey.setChildCount(index);
             relatedCacheKeys.add(toCacheKeyString(cacheKey));
@@ -88,7 +88,7 @@ public class CacheKeyUtils {
         return stringJoiner.toString();
     }
 
-    private boolean calculatePassengerCountLessThan9(CacheKey cacheKey) {
+    private boolean ifTotalPassengerCountLessThan9(CacheKey cacheKey) {
         return cacheKey.getSeniorCount()+ cacheKey.getAdultCount()+ cacheKey.getYouthCount()+ cacheKey.getChildCount()+ cacheKey.getInfantCount() < 9;
     }
 }

--- a/src/test/java/code/base/omio/CacheKeyUtilsTest.java
+++ b/src/test/java/code/base/omio/CacheKeyUtilsTest.java
@@ -1,0 +1,104 @@
+package code.base.omio;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class CacheKeyUtilsTest {
+
+    private CacheKeyUtils cacheKeyUtils = new CacheKeyUtils();
+
+    @Test
+    void for1Adult() {
+        String cacheKey = "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|0|0|0|<discCardHash>|<abParamterHash>";
+        List<String> relatedCacheKeys = cacheKeyUtils.getRelatedCacheKeys(cacheKey);
+
+        Assertions.assertThat(relatedCacheKeys).containsExactlyInAnyOrderElementsOf(List.of(
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|1|1|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|1|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|3|1|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|4|1|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|5|1|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|6|1|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|7|1|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|8|1|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|2|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|3|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|4|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|5|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|6|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|7|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|8|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|9|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|1|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|2|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|3|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|4|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|5|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|6|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|7|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|8|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|0|1|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|0|2|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|0|3|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|0|4|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|0|5|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|0|6|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|0|7|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|0|8|0|<discCardHash>|<abParamterHash>"
+
+        ));
+    }
+
+    @Test
+    void for2Senior2Adult() {
+        String cacheKey = "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|2|0|0|0|<discCardHash>|<abParamterHash>";
+        List<String> relatedCacheKeys = cacheKeyUtils.getRelatedCacheKeys(cacheKey);
+
+        Assertions.assertThat(relatedCacheKeys).containsExactlyInAnyOrderElementsOf(List.of(
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|3|2|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|4|2|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|5|2|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|6|2|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|7|2|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|3|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|4|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|5|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|6|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|7|0|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|2|1|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|2|2|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|2|3|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|2|4|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|2|5|0|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|2|0|1|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|2|0|2|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|2|0|3|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|2|0|4|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|2|0|5|0|<discCardHash>|<abParamterHash>"
+
+        ));
+    }
+
+    @Test
+    void forTotal9PassengersTheRelatedCacheKeyWillBeEmpty() {
+        String cacheKey = "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|3|1|2|1|<discCardHash>|<abParamterHash>";
+        List<String> relatedCacheKeys = cacheKeyUtils.getRelatedCacheKeys(cacheKey);
+
+        Assertions.assertThat(relatedCacheKeys).isEmpty();
+    }
+
+    @Test
+    void forTotal8PassengersWithNoInfant() {
+        String cacheKey = "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|3|1|2|0|<discCardHash>|<abParamterHash>";
+        List<String> relatedCacheKeys = cacheKeyUtils.getRelatedCacheKeys(cacheKey);
+
+        Assertions.assertThat(relatedCacheKeys).containsExactlyInAnyOrderElementsOf(List.of(
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|3|3|1|2|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|4|1|2|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|3|2|2|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|3|1|3|0|<discCardHash>|<abParamterHash>"
+        ));
+    }
+}

--- a/src/test/java/code/base/omio/CacheKeyUtilsTest.java
+++ b/src/test/java/code/base/omio/CacheKeyUtilsTest.java
@@ -10,7 +10,7 @@ class CacheKeyUtilsTest {
     private CacheKeyUtils cacheKeyUtils = new CacheKeyUtils();
 
     @Test
-    void for1Adult() {
+    void for1AdultRoundTrip() {
         String cacheKey = "deutscheBahn|12345|67890|2020-12-01|2020-12-02|0|1|0|0|0|<discCardHash>|<abParamterHash>";
         List<String> relatedCacheKeys = cacheKeyUtils.getRelatedCacheKeys(cacheKey);
 
@@ -52,7 +52,7 @@ class CacheKeyUtilsTest {
     }
 
     @Test
-    void for2Senior2Adult() {
+    void for2Senior2AdultRoundTrip() {
         String cacheKey = "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|2|0|0|0|<discCardHash>|<abParamterHash>";
         List<String> relatedCacheKeys = cacheKeyUtils.getRelatedCacheKeys(cacheKey);
 
@@ -90,7 +90,7 @@ class CacheKeyUtilsTest {
     }
 
     @Test
-    void forTotal8PassengersWithNoInfant() {
+    void forTotal8PassengersWithNoInfantRoundTrip() {
         String cacheKey = "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|3|1|2|0|<discCardHash>|<abParamterHash>";
         List<String> relatedCacheKeys = cacheKeyUtils.getRelatedCacheKeys(cacheKey);
 
@@ -99,6 +99,19 @@ class CacheKeyUtilsTest {
                 "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|4|1|2|0|<discCardHash>|<abParamterHash>",
                 "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|3|2|2|0|<discCardHash>|<abParamterHash>",
                 "deutscheBahn|12345|67890|2020-12-01|2020-12-02|2|3|1|3|0|<discCardHash>|<abParamterHash>"
+        ));
+    }
+
+    @Test
+    void forTotal8PassengersWithNoInfantOneWay() {
+        String cacheKey = "deutscheBahn|12345|67890|2020-12-01||2|3|1|2|0|<discCardHash>|<abParamterHash>";
+        List<String> relatedCacheKeys = cacheKeyUtils.getRelatedCacheKeys(cacheKey);
+
+        Assertions.assertThat(relatedCacheKeys).containsExactlyInAnyOrderElementsOf(List.of(
+                "deutscheBahn|12345|67890|2020-12-01||3|3|1|2|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01||2|4|1|2|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01||2|3|2|2|0|<discCardHash>|<abParamterHash>",
+                "deutscheBahn|12345|67890|2020-12-01||2|3|1|3|0|<discCardHash>|<abParamterHash>"
         ));
     }
 }


### PR DESCRIPTION
JIRA: https://goeuro.atlassian.net/browse/FND-1860

Description:
As a part of this PR, class `CacheKeyUtils` has method `getRelatedCacheKeys` which returns the related cachekeys for a given cache key.  Using these related cache keys we can perform delete in couchbase document